### PR TITLE
allow registering of discrete color schemes

### DIFF
--- a/src/schemes.js
+++ b/src/schemes.js
@@ -82,9 +82,14 @@ add('yellowgreen',       'YlGn');
 add('yelloworangebrown', 'YlOrBr');
 add('yelloworangered',   'YlOrRd');
 
-export default function(name, scheme) {
+export default function(name, scheme, discreteScheme) {
   if (arguments.length > 1) {
     schemes[name] = scheme;
+
+    if (discreteScheme) {
+      discrete[name] = discreteScheme;
+    }
+
     return this;
   }
 


### PR DESCRIPTION
This allows a 3rd parameter to the `scheme` function registering it's value in the `discrete` scheme registry.

This allows for custom color schemes to be registered and used with the `count` property of a color scheme object in a scales `range` property.

Useful in my case to register a custom diverging color schemes in different sizes like the ones provided by https://github.com/d3/d3-scale-chromatic.